### PR TITLE
Fix step import errors and add support for pause step type

### DIFF
--- a/internal/provider/resource_runscope_step.go
+++ b/internal/provider/resource_runscope_step.go
@@ -3,11 +3,12 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-runscope/internal/runscope"
-	"strconv"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -303,7 +304,7 @@ func resourceStepUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 
 	_, err := client.Step.Update(ctx, opts)
 	if err != nil {
-		return diag.Errorf("Couldn't create step: %s", err)
+		return diag.Errorf("Couldn't update step: %s", err)
 	}
 
 	return resourceStepRead(ctx, d, meta)
@@ -316,7 +317,7 @@ func resourceStepDelete(ctx context.Context, d *schema.ResourceData, meta interf
 	expandStepGetOpts(d, &opts.StepGetOpts)
 
 	if err := client.Step.Delete(ctx, opts); err != nil {
-		return diag.Errorf("Couldn't read step: %s", err)
+		return diag.Errorf("Couldn't delete step: %s", err)
 	}
 
 	return nil

--- a/internal/provider/resource_runscope_step.go
+++ b/internal/provider/resource_runscope_step.go
@@ -110,11 +110,11 @@ func resourceRunscopeStep() *schema.Resource {
 			},
 			"method": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true, // FIXME: this is required if the step_type is request
 			},
 			"url": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true, // FIXME: this is required if the step_type is request
 			},
 			"variable": {
 				Type: schema.TypeSet,
@@ -237,6 +237,11 @@ func resourceRunscopeStep() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"duration": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(0, 180),
+			},
 		},
 	}
 }
@@ -291,6 +296,7 @@ func resourceStepRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	d.Set("before_scripts", step.BeforeScripts)
 	d.Set("note", step.Note)
 	d.Set("skipped", step.Skipped)
+	d.Set("duration", step.Duration)
 
 	return nil
 }
@@ -370,5 +376,8 @@ func expandStepBaseOpts(d *schema.ResourceData, opts *runscope.StepBaseOpts) {
 	}
 	if v, ok := d.GetOk("skipped"); ok {
 		opts.Skipped = v.(bool)
+	}
+	if v, ok := d.GetOk("duration"); ok {
+		opts.Duration = v.(int)
 	}
 }

--- a/internal/runscope/schema/step.go
+++ b/internal/runscope/schema/step.go
@@ -28,10 +28,10 @@ type StepVariable struct {
 }
 
 type StepAssertion struct {
-	Source     string `json:"source"`
-	Property   string `json:"property"`
-	Comparison string `json:"comparison"`
-	Value      string `json:"value"`
+	Source     string          `json:"source"`
+	Property   string          `json:"property"`
+	Comparison string          `json:"comparison"`
+	Value      json.RawMessage `json:"value"`
 }
 
 type StepAuth struct {

--- a/internal/runscope/schema/step.go
+++ b/internal/runscope/schema/step.go
@@ -1,5 +1,7 @@
 package schema
 
+import "encoding/json"
+
 type StepBase struct {
 	StepType      string              `json:"step_type"`
 	Method        string              `json:"method"`
@@ -14,6 +16,7 @@ type StepBase struct {
 	BeforeScripts []string            `json:"before_scripts"`
 	Note          string              `json:"note"`
 	Skipped       bool                `json:"skipped"`
+	Duration      int                 `json:"duration"`
 }
 
 type Step struct {

--- a/internal/runscope/step.go
+++ b/internal/runscope/step.go
@@ -2,7 +2,9 @@ package runscope
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+
 	"github.com/terraform-providers/terraform-provider-runscope/internal/runscope/schema"
 )
 
@@ -49,11 +51,18 @@ func (sb *StepBase) setFromSchema(s *schema.Step) {
 		}
 	}
 	for i, a := range s.Assertions {
+		var value string
+		if len(a.Value) > 1 && a.Value[0] == '"' && a.Value[len(a.Value)-1] == '"' {
+			value = string(a.Value[1 : len(a.Value)-1])
+		} else {
+			value = string(a.Value)
+		}
+
 		sb.Assertions[i] = StepAssertion{
 			Source:     a.Source,
 			Property:   a.Property,
 			Comparison: a.Comparison,
-			Value:      a.Value,
+			Value:      value,
 		}
 	}
 	for header, values := range s.Headers {
@@ -172,7 +181,7 @@ func (sbo *StepBaseOpts) setRequest(sb *schema.StepBase) {
 		sb.Assertions[i] = schema.StepAssertion{
 			Source:     a.Source,
 			Comparison: a.Comparison,
-			Value:      a.Value,
+			Value:      (json.RawMessage)(string('"') + string(a.Value) + string('"')),
 			Property:   a.Property,
 		}
 	}

--- a/internal/runscope/step.go
+++ b/internal/runscope/step.go
@@ -22,6 +22,7 @@ type StepBase struct {
 	BeforeScripts []string
 	Note          string
 	Skipped       bool
+	Duration      int
 }
 
 func (sb *StepBase) setFromSchema(s *schema.Step) {
@@ -42,6 +43,7 @@ func (sb *StepBase) setFromSchema(s *schema.Step) {
 	sb.BeforeScripts = make([]string, len(s.BeforeScripts))
 	sb.Note = s.Note
 	sb.Skipped = s.Skipped
+	sb.Duration = s.Duration
 
 	for i, v := range s.Variables {
 		sb.Variables[i] = StepVariable{
@@ -149,6 +151,7 @@ type StepBaseOpts struct {
 	BeforeScripts []string
 	Note          string
 	Skipped       bool
+	Duration      int
 }
 
 func (sbo *StepBaseOpts) setRequest(sb *schema.StepBase) {
@@ -169,6 +172,7 @@ func (sbo *StepBaseOpts) setRequest(sb *schema.StepBase) {
 	sb.BeforeScripts = make([]string, len(sbo.BeforeScripts))
 	sb.Note = sbo.Note
 	sb.Skipped = sbo.Skipped
+	sb.Duration = sbo.Duration
 
 	for i, v := range sbo.Variables {
 		sb.Variables[i] = schema.StepVariable{


### PR DESCRIPTION
Handle assertions where the value type is int

We need to be able to use number types when creating, updating or
importing assertions of a response_status because the API returns a
number type for these field.

Fixes https://github.com/sport24ru/terraform-provider-runscope/issues/19

---

Add support for a pause step.

As part of this the method & url fields are no longer always required so
they're set to optional for now.